### PR TITLE
Security

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,6 @@
+MY_PUBLIC_SSH_KEY="ssh-ed25519 AAAA... youruser@yourhost.local"
+MY_WIREGUARD_CLIENT_KEY=sDMnoquotes+base64encodedclientprivatekey=
+MY_WIREGUARD_CLIENT_PUB=FSNnoquotes+base64encodedclientpublickey=
+MY_WIREGUARD_SERVER_PUB=gqrnoquotes+base64encodedserverpublickey=
+MY_WIREGUARD_SERVER_IPV6=2600::...1234ip.public.ipv6
+MY_PUBLIC_IP=12.34.56.my.public.ipv4

--- a/.env.prod.example
+++ b/.env.prod.example
@@ -1,0 +1,4 @@
+# Production environment configuration
+ACCOUNT_ID=12345678
+MFA_DEVICE_NAME=1passwordYourAWSIAMUserMFADevice
+OP_VAULT_ITEM="op://Kingdon/prod_WhereverYouStoredIt/one-time password?attribute=otp"

--- a/.env.sb.example
+++ b/.env.sb.example
@@ -1,0 +1,4 @@
+# Sandbox environment configuration
+ACCOUNT_ID=910123456
+MFA_DEVICE_NAME=1password-TestNameOfYourMFADeviceOnAWS
+OP_VAULT_ITEM="op://Kingdon/root_WhereverYouStoredMFAToken/one-time password?attribute=otp"

--- a/main.tf
+++ b/main.tf
@@ -36,6 +36,10 @@ module "bastion_ci" {
   instance_type             = "t4g.small"
   # assign from .env
   my_public_ssh_key         = local.env["MY_PUBLIC_SSH_KEY"]
+  my_wireguard_client_key   = local.env["MY_WIREGUARD_CLIENT_KEY"]
+  my_wireguard_client_pub   = local.env["MY_WIREGUARD_CLIENT_PUB"]
+  my_wireguard_server_pub   = local.env["MY_WIREGUARD_SERVER_PUB"]
+  my_wireguard_server_ipv6  = local.env["MY_WIREGUARD_SERVER_IPV6"]
 }
 
 module "vpc_eu_west_1" {

--- a/modules/bastion-ci/main.tf
+++ b/modules/bastion-ci/main.tf
@@ -74,8 +74,8 @@ resource "aws_launch_template" "bastion" {
 
   network_interfaces {
     subnet_id                   = element(var.public_subnet_ids, 0)
-    associate_public_ip_address = false # <– important, disables IPv4
-    ipv6_address_count          = 1     # <– asks for a single IPv6
+    associate_public_ip_address = false
+    ipv6_address_count          = 1
     security_groups             = [var.bastion_security_group_id, var.ssm_security_group_id]
   }
 
@@ -86,70 +86,14 @@ resource "aws_launch_template" "bastion" {
     }
   }
 
-  user_data = base64encode(<<-EOT
-              #!/usr/bin/env bash
-              set -euo pipefail
-
-              # Create SSH authorized_keys for ec2-user
-              mkdir -p /home/ec2-user/.ssh
-              echo "${var.my_public_ssh_key}" > /home/ec2-user/.ssh/authorized_keys
-              # echo "${var.my_wireguard_client_key}" > /root/client.key
-              # echo "${var.my_wireguard_client_pub}" > /root/client.pub
-              chown -R ec2-user:ec2-user /home/ec2-user/.ssh
-              chmod 700 /home/ec2-user/.ssh
-              chmod 600 /home/ec2-user/.ssh/authorized_keys
-
-              dnf update -y
-              dnf install -y git unzip jq iptables wireguard-tools
-              cd /root
-
-              # Without Wireguard to IPv4, could not install OpenTofu from IPv6
-              cat >/etc/wireguard/wg0.conf <<'EOP'
-              [Interface]
-              Address = 10.66.66.2/32, fd42:42:42::2/128
-              PrivateKey = ${var.my_wireguard_client_key}
-              # Optional: pick a DNS if you want the bastion to resolve via the server
-              # DNS = 1.1.1.1
-
-              [Peer]
-              # Your Debian server
-              PublicKey = ${var.my_wireguard_server_pub}
-              Endpoint = [${var.my_wireguard_server_ipv6}]:51820          # server's IPv6 address in brackets
-              AllowedIPs = 0.0.0.0/0, 10.66.66.0/24         # send ALL IPv4 via tunnel; keep IPv6 direct
-              PersistentKeepalive = 25
-              EOP
-              systemctl enable --now wg-quick@wg0
-
-              # Download the installer script:
-              curl --proto '=https' --tlsv1.2 -fsSL https://get.opentofu.org/install-opentofu.sh -o install-opentofu.sh
-              # Alternatively: wget --secure-protocol=TLSv1_2 --https-only https://get.opentofu.org/install-opentofu.sh -O install-opentofu.sh
-              # Give it execution permissions:
-              chmod +x install-opentofu.sh
-              # Please inspect the downloaded script
-              # Run the installer:
-              ./install-opentofu.sh --install-method rpm
-              # Remove the installer:
-              rm -f install-opentofu.sh
-
-              cat >/etc/profile.d/assume-tf-ci.sh <<'EOP'
-              export AWS_REGION=${var.region}
-              export AWS_PAGER=""
-              assume_tf_ci() {
-                CREDS=$(aws sts assume-role --role-arn ${aws_iam_role.terraform_ci.arn} --role-session-name tfci-$$)
-                export AWS_ACCESS_KEY_ID=$(echo $CREDS | jq -r .Credentials.AccessKeyId)
-                export AWS_SECRET_ACCESS_KEY=$(echo $CREDS | jq -r .Credentials.SecretAccessKey)
-                export AWS_SESSION_TOKEN=$(echo $CREDS | jq -r .Credentials.SessionToken)
-                echo "Assumed ${aws_iam_role.terraform_ci.arn}"
-              }
-              EOP
-
-              # SSM Agent is preinstalled on AL2/AL2023; ensure it's running
-              systemctl enable amazon-ssm-agent
-              systemctl start amazon-ssm-agent
-              echo "Bootstrap complete" | logger
-
-              EOT
-  )
+  user_data = base64encode(templatefile("${path.module}/templates/userdata.tftpl", {
+    my_public_ssh_key     = var.my_public_ssh_key
+    my_wireguard_client_key = var.my_wireguard_client_key
+    my_wireguard_server_pub = var.my_wireguard_server_pub
+    my_wireguard_server_ipv6 = var.my_wireguard_server_ipv6
+    region                = var.region
+    terraform_ci_role_arn = aws_iam_role.terraform_ci.arn
+  }))
 }
 
 # Auto Scaling group

--- a/modules/bastion-ci/main.tf
+++ b/modules/bastion-ci/main.tf
@@ -93,13 +93,33 @@ resource "aws_launch_template" "bastion" {
               # Create SSH authorized_keys for ec2-user
               mkdir -p /home/ec2-user/.ssh
               echo "${var.my_public_ssh_key}" > /home/ec2-user/.ssh/authorized_keys
+              # echo "${var.my_wireguard_client_key}" > /root/client.key
+              # echo "${var.my_wireguard_client_pub}" > /root/client.pub
               chown -R ec2-user:ec2-user /home/ec2-user/.ssh
               chmod 700 /home/ec2-user/.ssh
               chmod 600 /home/ec2-user/.ssh/authorized_keys
 
               dnf update -y
-              dnf install -y git unzip jq
+              dnf install -y git unzip jq iptables wireguard-tools
               cd /root
+
+              # Without Wireguard to IPv4, could not install OpenTofu from IPv6
+              cat >/etc/wireguard/wg0.conf <<'EOP'
+              [Interface]
+              Address = 10.66.66.2/32, fd42:42:42::2/128
+              PrivateKey = ${var.my_wireguard_client_key}
+              # Optional: pick a DNS if you want the bastion to resolve via the server
+              # DNS = 1.1.1.1
+
+              [Peer]
+              # Your Debian server
+              PublicKey = ${var.my_wireguard_server_pub}
+              Endpoint = [${var.my_wireguard_server_ipv6}]:51820          # server's IPv6 address in brackets
+              AllowedIPs = 0.0.0.0/0, 10.66.66.0/24         # send ALL IPv4 via tunnel; keep IPv6 direct
+              PersistentKeepalive = 25
+              EOP
+              systemctl enable --now wg-quick@wg0
+
               # Download the installer script:
               curl --proto '=https' --tlsv1.2 -fsSL https://get.opentofu.org/install-opentofu.sh -o install-opentofu.sh
               # Alternatively: wget --secure-protocol=TLSv1_2 --https-only https://get.opentofu.org/install-opentofu.sh -O install-opentofu.sh

--- a/modules/bastion-ci/main.tf
+++ b/modules/bastion-ci/main.tf
@@ -62,6 +62,21 @@ resource "aws_iam_instance_profile" "bastion" {
 
 # Security group is now managed by the VPC module
 
+# Log group
+resource "aws_cloudwatch_log_group" "bastion" {
+  name              = "/bastion/logs"
+  retention_in_days = 30
+  tags = {
+    Name = "${var.name}-bastion"
+  }
+}
+
+# Policy attachment for CloudWatch agent
+resource "aws_iam_role_policy_attachment" "bastion_cwagent" {
+  role       = aws_iam_role.bastion_role.name
+  policy_arn = "arn:aws:iam::aws:policy/CloudWatchAgentServerPolicy"
+}
+
 # Launch template for bastion
 resource "aws_launch_template" "bastion" {
   name_prefix   = "${var.name}-lt-"

--- a/modules/bastion-ci/main.tf
+++ b/modules/bastion-ci/main.tf
@@ -87,6 +87,13 @@ resource "aws_launch_template" "bastion" {
     arn = aws_iam_instance_profile.bastion.arn
   }
 
+  metadata_options {
+    http_endpoint               = "enabled"   # allows IMDS
+    http_tokens                 = "required"  # enforce IMDSv2
+    http_protocol_ipv6           = "enabled"  # allow IPv6
+    http_put_response_hop_limit = 2           # standard
+  }
+
   network_interfaces {
     subnet_id                   = element(var.public_subnet_ids, 0)
     associate_public_ip_address = false

--- a/modules/bastion-ci/templates/userdata.tftpl
+++ b/modules/bastion-ci/templates/userdata.tftpl
@@ -9,7 +9,7 @@ chmod 700 /home/ec2-user/.ssh
 chmod 600 /home/ec2-user/.ssh/authorized_keys
 
 dnf update -y
-dnf install -y git unzip jq iptables wireguard-tools
+dnf install -y git unzip jq iptables wireguard-tools amazon-cloudwatch-agent
 cd /root
 
 # WireGuard config
@@ -32,6 +32,39 @@ curl --proto '=https' --tlsv1.2 -fsSL https://get.opentofu.org/install-opentofu.
 chmod +x install-opentofu.sh
 ./install-opentofu.sh --install-method rpm
 rm -f install-opentofu.sh
+
+# Enable CloudWatch
+cat >/opt/aws/amazon-cloudwatch-agent/etc/amazon-cloudwatch-agent.json <<'EOP'
+{
+  "agent": {
+    "metrics_collection_interval": 60,
+    "run_as_user": "root"
+  },
+  "metrics": {
+    "append_dimensions": {
+      "InstanceId": "$${aws:InstanceId}"
+    },
+    "metrics_collected": {
+      "mem": { "measurement": ["mem_used_percent"] },
+      "cpu": { "measurement": ["cpu_usage_idle", "cpu_usage_user", "cpu_usage_system"], "metrics_collection_interval": 60 },
+      "disk": { "measurement": ["used_percent"], "resources": ["*"] },
+      "net": { "measurement": ["bytes_in", "bytes_out"], "resources": ["*"] }
+    }
+  },
+  "logs": {
+    "logs_collected": {
+      "files": {
+        "collect_list": [
+          { "file_path": "/var/log/messages", "log_group_name": "bastion", "log_stream_name": "{instance_id}" }
+        ]
+      }
+    }
+  }
+}
+EOP
+
+systemctl enable amazon-cloudwatch-agent
+systemctl start amazon-cloudwatch-agent
 
 # Assume role helper
 cat >/etc/profile.d/assume-tf-ci.sh <<EOP

--- a/modules/bastion-ci/templates/userdata.tftpl
+++ b/modules/bastion-ci/templates/userdata.tftpl
@@ -26,6 +26,8 @@ PersistentKeepalive = 25
 EOP
 
 systemctl enable --now wg-quick@wg0
+# Do not route IMDS traffic over Wireguard!
+ip route add 169.254.169.254/32 dev ens5
 
 # Install OpenTofu
 curl --proto '=https' --tlsv1.2 -fsSL https://get.opentofu.org/install-opentofu.sh -o install-opentofu.sh
@@ -62,13 +64,6 @@ cat >/opt/aws/amazon-cloudwatch-agent/etc/amazon-cloudwatch-agent.json <<'EOP'
   }
 }
 EOP
-
-cat >/etc/profile.d/cwagent-ipv6.sh <<'EOP'
-export AWS_EC2_METADATA_SERVICE_ENDPOINT="http://[fd00:ec2::254]"
-EOP
-
-# Make it active immediately
-source /etc/profile.d/cwagent-ipv6.sh
 
 systemctl enable amazon-cloudwatch-agent
 systemctl start amazon-cloudwatch-agent

--- a/modules/bastion-ci/templates/userdata.tftpl
+++ b/modules/bastion-ci/templates/userdata.tftpl
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Create SSH authorized_keys for ec2-user
+mkdir -p /home/ec2-user/.ssh
+echo "${my_public_ssh_key}" > /home/ec2-user/.ssh/authorized_keys
+chown -R ec2-user:ec2-user /home/ec2-user/.ssh
+chmod 700 /home/ec2-user/.ssh
+chmod 600 /home/ec2-user/.ssh/authorized_keys
+
+dnf update -y
+dnf install -y git unzip jq iptables wireguard-tools
+cd /root
+
+# WireGuard config
+cat >/etc/wireguard/wg0.conf <<EOP
+[Interface]
+Address = 10.66.66.2/32, fd42:42:42::2/128
+PrivateKey = ${my_wireguard_client_key}
+
+[Peer]
+PublicKey = ${my_wireguard_server_pub}
+Endpoint = [${my_wireguard_server_ipv6}]:51820
+AllowedIPs = 0.0.0.0/0, 10.66.66.0/24
+PersistentKeepalive = 25
+EOP
+
+systemctl enable --now wg-quick@wg0
+
+# Install OpenTofu
+curl --proto '=https' --tlsv1.2 -fsSL https://get.opentofu.org/install-opentofu.sh -o install-opentofu.sh
+chmod +x install-opentofu.sh
+./install-opentofu.sh --install-method rpm
+rm -f install-opentofu.sh
+
+# Assume role helper
+cat >/etc/profile.d/assume-tf-ci.sh <<EOP
+export AWS_REGION=${region}
+export AWS_PAGER=""
+assume_tf_ci() {
+  CREDS=$(aws sts assume-role --role-arn ${terraform_ci_role_arn} --role-session-name tfci-$$)
+  export AWS_ACCESS_KEY_ID=$(echo $CREDS | jq -r .Credentials.AccessKeyId)
+  export AWS_SECRET_ACCESS_KEY=$(echo $CREDS | jq -r .Credentials.SecretAccessKey)
+  export AWS_SESSION_TOKEN=$(echo $CREDS | jq -r .Credentials.SessionToken)
+  echo "Assumed ${terraform_ci_role_arn}"
+}
+EOP
+
+systemctl enable amazon-ssm-agent
+systemctl start amazon-ssm-agent
+echo "Bootstrap complete" | logger

--- a/modules/bastion-ci/templates/userdata.tftpl
+++ b/modules/bastion-ci/templates/userdata.tftpl
@@ -55,7 +55,7 @@ cat >/opt/aws/amazon-cloudwatch-agent/etc/amazon-cloudwatch-agent.json <<'EOP'
     "logs_collected": {
       "files": {
         "collect_list": [
-          { "file_path": "/var/log/messages", "log_group_name": "bastion", "log_stream_name": "{instance_id}" }
+          { "file_path": "/var/log/messages", "log_group_name": "/bastion/logs", "log_stream_name": "{instance_id}" }
         ]
       }
     }

--- a/modules/bastion-ci/templates/userdata.tftpl
+++ b/modules/bastion-ci/templates/userdata.tftpl
@@ -63,6 +63,13 @@ cat >/opt/aws/amazon-cloudwatch-agent/etc/amazon-cloudwatch-agent.json <<'EOP'
 }
 EOP
 
+cat >/etc/profile.d/cwagent-ipv6.sh <<'EOP'
+export AWS_EC2_METADATA_SERVICE_ENDPOINT="http://[fd00:ec2::254]"
+EOP
+
+# Make it active immediately
+source /etc/profile.d/cwagent-ipv6.sh
+
 systemctl enable amazon-cloudwatch-agent
 systemctl start amazon-cloudwatch-agent
 

--- a/modules/bastion-ci/templates/userdata.tftpl
+++ b/modules/bastion-ci/templates/userdata.tftpl
@@ -50,14 +50,14 @@ cat >/opt/aws/amazon-cloudwatch-agent/etc/amazon-cloudwatch-agent.json <<'EOP'
       "mem": { "measurement": ["mem_used_percent"] },
       "cpu": { "measurement": ["cpu_usage_idle", "cpu_usage_user", "cpu_usage_system"], "metrics_collection_interval": 60 },
       "disk": { "measurement": ["used_percent"], "resources": ["*"] },
-      "net": { "measurement": ["bytes_in", "bytes_out"], "resources": ["*"] }
+      "net": { "measurement": ["bytes_sent", "bytes_recv", "packets_sent", "packets_recv"], "resources": ["*"] }
     }
   },
   "logs": {
     "logs_collected": {
       "files": {
         "collect_list": [
-          { "file_path": "/var/log/messages", "log_group_name": "/bastion/logs", "log_stream_name": "{instance_id}" }
+          { "file_path": "/var/log/cloud-init-output.log", "log_group_name": "/bastion/logs", "log_stream_name": "{instance_id}" }
         ]
       }
     }

--- a/modules/bastion-ci/variables.tf
+++ b/modules/bastion-ci/variables.tf
@@ -44,3 +44,23 @@ variable "my_public_ssh_key" {
   description = "Public SSH key of the user who should get ec2-user access"
   type        = string
 }
+
+variable "my_wireguard_client_key" {
+  description = "Private key for the wireguard client"
+  type        = string
+}
+
+variable "my_wireguard_client_pub" {
+  description = "Public key for the client's wireguard key"
+  type        = string
+}
+
+variable "my_wireguard_server_pub" {
+  description = "Public key for the wireguard server"
+  type        = string
+}
+
+variable "my_wireguard_server_ipv6" {
+  description = "Public IPv6 address for the wireguard server"
+  type        = string
+}


### PR DESCRIPTION
We had to get an IPv4 link in order to install OpenTofu, but we did not want to pay AWS for it

So we made our user_data script a bit more complex & added wireguard, then of course you need cloudwatch which means IMDS and a log group, and we've split out user_data into a separate file of its own (so we don't have to embed it in HCL!)